### PR TITLE
Simplify AbstractEngineTileEntities

### DIFF
--- a/src/main/java/com/drmangotea/createindustry/blocks/engines/small/AbstractEngineTileEntity.java
+++ b/src/main/java/com/drmangotea/createindustry/blocks/engines/small/AbstractEngineTileEntity.java
@@ -192,6 +192,10 @@ boolean signalChanged;
 
     }
 
+    public EngineBackPartBlock backPartBlock(){
+        return TFMGBlocks.GASOLINE_ENGINE_BACK.get();
+    }
+
     public boolean hasBackPart(){
         BlockPos wantedLocation=this.getBlockPos();
         Direction direction = this.getBlockState().getValue(DirectionalBlock.FACING);
@@ -211,14 +215,9 @@ boolean signalChanged;
             wantedLocation=this.getBlockPos().west();
 
 
-
-        if(!level.getBlockState(wantedLocation).is(TFMGBlocks.GASOLINE_ENGINE_BACK.get())) {
-            return false;
-        }else {
-            if ( level.getBlockState(wantedLocation).getValue(DirectionalBlock.FACING) != direction)
-                return false;
-        }
-            return true;
+        BlockState wantedLocationBlockState = level.getBlockState(wantedLocation);
+        return wantedLocationBlockState.is(backPartBlock())
+                && wantedLocationBlockState.getValue(DirectionalBlock.FACING) == direction;
     }
 
     @Override

--- a/src/main/java/com/drmangotea/createindustry/blocks/engines/small/gasoline/GasolineEngineTileEntity.java
+++ b/src/main/java/com/drmangotea/createindustry/blocks/engines/small/gasoline/GasolineEngineTileEntity.java
@@ -2,22 +2,14 @@ package com.drmangotea.createindustry.blocks.engines.small.gasoline;
 
 
 import com.drmangotea.createindustry.blocks.engines.small.AbstractEngineTileEntity;
-import com.drmangotea.createindustry.registry.TFMGFluids;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.material.Fluid;
 
 public class GasolineEngineTileEntity extends AbstractEngineTileEntity {
 
 
     public GasolineEngineTileEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
-
-    }
-
-    @Override
-    public Fluid validFuel() {
-        return TFMGFluids.GASOLINE.getSource();
     }
 }

--- a/src/main/java/com/drmangotea/createindustry/blocks/engines/small/lpg/LPGEngineTileEntity.java
+++ b/src/main/java/com/drmangotea/createindustry/blocks/engines/small/lpg/LPGEngineTileEntity.java
@@ -2,11 +2,10 @@ package com.drmangotea.createindustry.blocks.engines.small.lpg;
 
 
 import com.drmangotea.createindustry.blocks.engines.small.AbstractEngineTileEntity;
+import com.drmangotea.createindustry.blocks.engines.small.EngineBackPartBlock;
 import com.drmangotea.createindustry.registry.TFMGBlocks;
 import com.drmangotea.createindustry.registry.TFMGFluids;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.world.level.block.DirectionalBlock;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluid;
@@ -18,35 +17,12 @@ public class LPGEngineTileEntity extends AbstractEngineTileEntity {
         super(type, pos, state);
 
     }
+
     @Override
-    public boolean hasBackPart(){
-        BlockPos wantedLocation=this.getBlockPos();
-        Direction direction = this.getBlockState().getValue(DirectionalBlock.FACING);
-
-
-        if(direction == Direction.UP)
-            wantedLocation=this.getBlockPos().below();
-        if(direction == Direction.DOWN)
-            wantedLocation=this.getBlockPos().above();
-        if(direction == Direction.NORTH)
-            wantedLocation=this.getBlockPos().south();
-        if(direction == Direction.SOUTH)
-            wantedLocation=this.getBlockPos().north();
-        if(direction == Direction.WEST)
-            wantedLocation=this.getBlockPos().east();
-        if(direction == Direction.EAST)
-            wantedLocation=this.getBlockPos().west();
-
-
-
-        if(!level.getBlockState(wantedLocation).is(TFMGBlocks.LPG_ENGINE_BACK.get())) {
-            return false;
-        }else {
-            if ( level.getBlockState(wantedLocation).getValue(DirectionalBlock.FACING) != direction)
-                return false;
-        }
-        return true;
+    public EngineBackPartBlock backPartBlock() {
+        return TFMGBlocks.LPG_ENGINE_BACK.get();
     }
+
     @Override
     public Fluid validFuel() {
         return TFMGFluids.LPG.getSource();

--- a/src/main/java/com/drmangotea/createindustry/blocks/engines/small/turbine/TurbineEngineTileEntity.java
+++ b/src/main/java/com/drmangotea/createindustry/blocks/engines/small/turbine/TurbineEngineTileEntity.java
@@ -2,14 +2,11 @@ package com.drmangotea.createindustry.blocks.engines.small.turbine;
 
 
 import com.drmangotea.createindustry.blocks.engines.small.AbstractEngineTileEntity;
+import com.drmangotea.createindustry.blocks.engines.small.EngineBackPartBlock;
 import com.drmangotea.createindustry.registry.TFMGBlocks;
-import com.drmangotea.createindustry.registry.TFMGFluids;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.world.level.block.DirectionalBlock;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.material.Fluid;
 
 public class TurbineEngineTileEntity extends AbstractEngineTileEntity {
 
@@ -20,36 +17,7 @@ public class TurbineEngineTileEntity extends AbstractEngineTileEntity {
     }
 
     @Override
-    public boolean hasBackPart(){
-        BlockPos wantedLocation=this.getBlockPos();
-        Direction direction = this.getBlockState().getValue(DirectionalBlock.FACING);
-
-
-        if(direction == Direction.UP)
-            wantedLocation=this.getBlockPos().below();
-        if(direction == Direction.DOWN)
-            wantedLocation=this.getBlockPos().above();
-        if(direction == Direction.NORTH)
-            wantedLocation=this.getBlockPos().south();
-        if(direction == Direction.SOUTH)
-            wantedLocation=this.getBlockPos().north();
-        if(direction == Direction.WEST)
-            wantedLocation=this.getBlockPos().east();
-        if(direction == Direction.EAST)
-            wantedLocation=this.getBlockPos().west();
-
-
-
-        if(!level.getBlockState(wantedLocation).is(TFMGBlocks.TURBINE_ENGINE_BACK.get())) {
-            return false;
-        }else {
-            if ( level.getBlockState(wantedLocation).getValue(DirectionalBlock.FACING) != direction)
-                return false;
-        }
-        return true;
-    }
-    @Override
-    public Fluid validFuel() {
-        return TFMGFluids.KEROSENE.getSource();
+    public EngineBackPartBlock backPartBlock() {
+        return TFMGBlocks.TURBINE_ENGINE_BACK.get();
     }
 }


### PR DESCRIPTION
hasBackPart() didn't need to be entirely redefined in inherited classes. I added the backPartBlock() method instead that is now overridden on inherited classes. I made backPartBlock() return TFMGBlocks.GASOLINE_ENGINE_BACK by default so the functionality is the same as before.