### PR TITLE
Use tag for fluids burnable in flarestack

### DIFF
--- a/src/generated/resources/.cache/2d06ea55ee27bcb1f7f87fa8ec3e037afa7e1ad9
+++ b/src/generated/resources/.cache/2d06ea55ee27bcb1f7f87fa8ec3e037afa7e1ad9
@@ -1,4 +1,4 @@
-// 1.19.2	2024-01-12T20:54:31.7281576	Registrate Provider for createindustry [Recipes, Advancements, Loot tables, Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), Blockstates, Item models, Lang (en_us/en_ud)]
+// 1.19.2	2024-02-17T07:48:34.5879678	Registrate Provider for createindustry [Recipes, Advancements, Loot tables, Tags (blocks), Tags (items), Tags (fluids), Tags (entity_types), Blockstates, Item models, Lang (en_us/en_ud)]
 50db526af77cf0ead08cadfd3f7daa8b84a40312 assets/createindustry/blockstates/air_intake.json
 429437419b2ec98bd716e7ba15583b84da7488d5 assets/createindustry/blockstates/aluminum_bars.json
 9e2417e479011e42ebf00685068e6b6f515f0b11 assets/createindustry/blockstates/aluminum_block.json
@@ -1147,6 +1147,7 @@ b36ae4afda731f02f9e9b90da534184e4e6300f0 data/createindustry/recipes/small_bauxi
 76687910efa99f4c1a04429ef5f6846c594f97eb data/createindustry/recipes/steel_bars_from_ingots_steel_stonecutting.json
 4bd3f4b3e1612feee9253f9a77ffc8b03afca749 data/createindustry/recipes/steel_ladder_from_ingots_steel_stonecutting.json
 3a8f9eee9835e5400a9dd664a150985ce336fa61 data/createindustry/recipes/steel_scaffolding_from_ingots_steel_stonecutting.json
+bcd62852c0944a152b179e509ac5b5856267367f data/createindustry/tags/fluids/is_burnable_fluid.json
 9790752bec1ad9dc61eb08c66e62caa28516713c data/createindustry/tags/items/stone_types/bauxite.json
 5117a7556fb8ef2531c9953e9923b8fb0ce8e3d6 data/create/tags/blocks/casing.json
 f562d1124549d82b6df1ef54fc09a15a5ada6b4d data/create/tags/blocks/fan_transparent.json

--- a/src/generated/resources/.cache/9047e4e94996e73e9dfde3738763637fb609e07e
+++ b/src/generated/resources/.cache/9047e4e94996e73e9dfde3738763637fb609e07e
@@ -1,2 +1,2 @@
-// 1.19.2	2024-01-12T20:54:31.7261534	Create: The Factory Must Grow's lang merger
-98af1b1ba96b233fd0d321a932d7f5dcde5e7f19 assets/createindustry/lang/en_us.json
+// 1.19.2	2024-02-17T07:39:53.6025831	Create: The Factory Must Grow's lang merger
+474208db87f05f358a5c15ca5268b8c0377c5d60 assets/createindustry/lang/en_us.json

--- a/src/generated/resources/data/createindustry/tags/fluids/is_burnable_fluid.json
+++ b/src/generated/resources/data/createindustry/tags/fluids/is_burnable_fluid.json
@@ -1,0 +1,28 @@
+{
+  "values": [
+    "createindustry:flowing_lpg",
+    "createindustry:lpg",
+    "createindustry:flowing_propane",
+    "createindustry:propane",
+    "createindustry:flowing_butane",
+    "createindustry:butane",
+    "createindustry:flowing_ethylene",
+    "createindustry:ethylene",
+    "createindustry:flowing_propylene",
+    "createindustry:propylene",
+    "createindustry:flowing_gasoline",
+    "createindustry:gasoline",
+    "createindustry:flowing_diesel",
+    "createindustry:diesel",
+    "createindustry:flowing_kerosene",
+    "createindustry:kerosene",
+    "createindustry:flowing_naphtha",
+    "createindustry:naphtha",
+    "createindustry:flowing_heavy_oil",
+    "createindustry:heavy_oil",
+    "createindustry:flowing_lubrication_oil",
+    "createindustry:lubrication_oil",
+    "createindustry:flowing_creosote",
+    "createindustry:creosote"
+  ]
+}

--- a/src/main/java/com/drmangotea/createindustry/blocks/machines/flarestack/FlarestackBlockEntity.java
+++ b/src/main/java/com/drmangotea/createindustry/blocks/machines/flarestack/FlarestackBlockEntity.java
@@ -127,19 +127,7 @@ public class FlarestackBlockEntity extends SmartBlockEntity implements IHaveGogg
         return new SmartFluidTank(1000, this::onFluidStackChanged) {
             @Override
             public boolean isFluidValid(FluidStack stack) {
-                return
-                        stack.getFluid().isSame(TFMGFluids.BUTANE.getSource())||
-                        stack.getFluid().isSame(TFMGFluids.PROPANE.getSource())||
-                        stack.getFluid().isSame(TFMGFluids.LPG.getSource())||
-                        stack.getFluid().isSame(TFMGFluids.KEROSENE.getSource())||
-                        stack.getFluid().isSame(TFMGFluids.NAPHTHA.getSource())||
-                        stack.getFluid().isSame(TFMGFluids.ETHYLENE.getSource())||
-                        stack.getFluid().isSame(TFMGFluids.PROPYLENE.getSource())||
-                        stack.getFluid().isSame(TFMGFluids.DIESEL.getSource())||
-                        stack.getFluid().isSame(TFMGFluids.LUBRICATION_OIL.getSource())||
-                        stack.getFluid().isSame(TFMGFluids.HEAVY_OIL.getSource())||
-                        stack.getFluid().isSame(TFMGFluids.CREOSOTE.getSource())||
-                        stack.getFluid().isSame(TFMGFluids.GASOLINE.getSource());
+                return stack.getFluid().is(TFMGFluids.IS_BURNABLE_FLUID);
             }
         };
     }

--- a/src/main/java/com/drmangotea/createindustry/registry/TFMGFluids.java
+++ b/src/main/java/com/drmangotea/createindustry/registry/TFMGFluids.java
@@ -15,12 +15,19 @@ import com.simibubi.create.content.fluids.VirtualFluid;
 import com.tterrag.registrate.util.entry.FluidEntry;
 
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.item.BucketItem;
+import net.minecraft.world.level.material.Fluid;
 import net.minecraftforge.fluids.ForgeFlowingFluid;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import static com.drmangotea.createindustry.CreateTFMG.REGISTRATE;
 
 public class TFMGFluids {
+
+    public static final TagKey<Fluid> IS_BURNABLE_FLUID = AllTags.optionalTag(ForgeRegistries.FLUIDS, new ResourceLocation(CreateTFMG.MOD_ID, "is_burnable_fluid"));
+
+
 
     public static final ResourceLocation CONCRETE_RL = CreateTFMG.asResource("fluid/liquid_concrete");
 
@@ -85,6 +92,7 @@ public class TFMGFluids {
     public static final FluidEntry<VirtualFluid> LPG =
             REGISTRATE.virtualFluid("lpg",LPG_RL,LPG_RL)
                     .lang("LPG")
+                    .tag(IS_BURNABLE_FLUID)
                     .register();
 
     public static final FluidEntry<VirtualFluid> AIR =
@@ -95,21 +103,25 @@ public class TFMGFluids {
     public static final FluidEntry<VirtualFluid> PROPANE =
             REGISTRATE.virtualFluid("propane",PROPANE_RL,PROPANE_RL)
                     .lang("Propane")
+                    .tag(IS_BURNABLE_FLUID)
                     .register();
 
     public static final FluidEntry<VirtualFluid> BUTANE =
             REGISTRATE.virtualFluid("butane",BUTANE_RL,BUTANE_RL)
                     .lang("Butane")
+                    .tag(IS_BURNABLE_FLUID)
                     .register();
 
     public static final FluidEntry<VirtualFluid> ETHYLENE =
             REGISTRATE.virtualFluid("ethylene",BUTANE_RL,BUTANE_RL)
                     .lang("Ethylene")
+                    .tag(IS_BURNABLE_FLUID)
                     .register();
 
     public static final FluidEntry<VirtualFluid> PROPYLENE =
             REGISTRATE.virtualFluid("propylene",PROPANE_RL,PROPANE_RL)
                     .lang("Propylene")
+                    .tag(IS_BURNABLE_FLUID)
                     .register();
 
 
@@ -191,6 +203,7 @@ public class TFMGFluids {
                             .tickRate(7)
                             .slopeFindDistance(5)
                             .explosionResistance(100f))
+                    .tag(IS_BURNABLE_FLUID)
 
                     .source(BurnableFluid.Source::new)
                     .bucket()
@@ -209,6 +222,7 @@ public class TFMGFluids {
                             .tickRate(7)
                             .slopeFindDistance(5)
                             .explosionResistance(100f))
+                    .tag(IS_BURNABLE_FLUID)
 
                     .source(BurnableFluid.Source::new)
                     .bucket()
@@ -225,6 +239,7 @@ public class TFMGFluids {
                             .tickRate(7)
                             .slopeFindDistance(5)
                             .explosionResistance(100f))
+                    .tag(IS_BURNABLE_FLUID)
 
                     .source(BurnableFluid.Source::new)
                     .bucket()
@@ -241,6 +256,7 @@ public class TFMGFluids {
                             .tickRate(7)
                             .slopeFindDistance(5)
                             .explosionResistance(100f))
+                    .tag(IS_BURNABLE_FLUID)
 
                     .source(BurnableFluid.Source::new)
                     .bucket()
@@ -257,6 +273,7 @@ public class TFMGFluids {
                             .tickRate(10)
                             .slopeFindDistance(5)
                             .explosionResistance(100f))
+                    .tag(IS_BURNABLE_FLUID)
 
                     .source(BurnableFluid.Source::new)
                     .bucket()
@@ -272,6 +289,7 @@ public class TFMGFluids {
                             .tickRate(7)
                             .slopeFindDistance(5)
                             .explosionResistance(100f))
+                    .tag(IS_BURNABLE_FLUID)
 
                     .source(BurnableFluid.Source::new)
                     .bucket()
@@ -316,6 +334,7 @@ public class TFMGFluids {
                             .tickRate(10)
                             .slopeFindDistance(5)
                             .explosionResistance(100f))
+                    .tag(IS_BURNABLE_FLUID)
 
                     .source(BurnableFluid.Source::new)
                     .bucket(CreosoteBucketItem::new)
@@ -371,7 +390,6 @@ public class TFMGFluids {
 
     public static void register() {
     }
-
 /*
     private static class NoColorFluidAttributes extends FluidType {
 


### PR DESCRIPTION
Uses a fluid tag `is_burnable_fluid` to determine which fluids are able to be burned in the flarestack.
Allows for greater mod compatibility.