### PR TITLE
Fix Output Fluid in AdvancedDistillationCategory

### DIFF
--- a/src/main/java/com/drmangotea/createindustry/recipes/jei/AdvancedDistillationCategory.java
+++ b/src/main/java/com/drmangotea/createindustry/recipes/jei/AdvancedDistillationCategory.java
@@ -51,7 +51,7 @@ public class AdvancedDistillationCategory extends CreateRecipeCategory<Distillat
 					.addSlot(RecipeIngredientRole.OUTPUT, 105, y)
 					.setBackground(getRenderedSlot(), -1, -1)
 					.addIngredient(ForgeTypes.FLUID_STACK, withImprovedVisibility(recipe.getFluidResults().get(i)))
-					.addTooltipCallback(addFluidTooltip(recipe.getFirstFluidResult().getAmount()));
+					.addTooltipCallback(addFluidTooltip(recipe.getFluidResults().get(i).getAmount()));
 		}
 
 	}


### PR DESCRIPTION
For some reason every fluid output was using the amount of the first output.  This fixes that. @DrMango14 you better merge this or I'll take your liver.