### PR TITLE
fix(polarizer): allow the player to put any item into the Polarizer

### DIFF
--- a/src/main/java/com/drmangotea/tfmg/blocks/electricity/polarizer/PolarizerBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/blocks/electricity/polarizer/PolarizerBlockEntity.java
@@ -147,10 +147,10 @@ public class PolarizerBlockEntity extends ElectricBlockEntity implements IHaveGo
         if(inventory.isEmpty()) {
 
 
-            if (player.getItemInHand(hand).is(TFMGItems.STEEL_INGOT.get())) {
+            if (!player.getItemInHand(hand).isEmpty()) {
 
 
-                inventory.setStackInSlot(0, TFMGItems.STEEL_INGOT.asStack());
+                inventory.setStackInSlot(0, player.getItemInHand(hand).copyWithCount(1));
                 sendStuff();
 
                 player.getItemInHand(hand).shrink(1);


### PR DESCRIPTION
# Allow the player to put any item into the Polarizer

Creating custom recipes for the *Polarizer* (like with **KubeJS**, see code example below) wasn't possible because only *Steel Ingots* could be put into it.

With this fix, any item can be now put into the *Polarizer* and custom recipes now work.
> [!NOTE]  
> If no recipe exists with the item, nothing happens.

---

Example of **KubeJS** script (in `kubejs/server_scripts/`) to transform a *Gold Ingot* into a *Diamond* using the *Polarizer*:
```js
// priority: 0

ServerEvents.recipes(event => {
    event.custom({
        type: "tfmg:polarizing",
        ingredients: [
            { tag: "forge:ingots/gold" }
        ],
        processingTime: 250,
        results: [
            { item: "minecraft:diamond" }
        ],
        energy: 150
    });
});
```