### PR TITLE
1.20.1 - Fix server crash caused by PolarizerBlockEntity

### DIFF
--- a/src/main/java/com/drmangotea/tfmg/blocks/electricity/polarizer/PolarizerBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/blocks/electricity/polarizer/PolarizerBlockEntity.java
@@ -5,14 +5,12 @@ import com.drmangotea.tfmg.base.TFMGUtils;
 import com.drmangotea.tfmg.blocks.electricity.base.ElectricBlockEntity;
 import com.drmangotea.tfmg.recipes.polarizing.PolarizingRecipe;
 import com.drmangotea.tfmg.registry.TFMGBlockEntities;
-import com.drmangotea.tfmg.registry.TFMGItems;
 import com.drmangotea.tfmg.registry.TFMGRecipeTypes;
 import com.simibubi.create.content.equipment.goggles.IHaveGoggleInformation;
 import com.simibubi.create.content.processing.sequenced.SequencedAssemblyRecipe;
 import com.simibubi.create.foundation.item.SmartInventory;
 import com.simibubi.create.foundation.utility.Lang;
 import net.minecraft.ChatFormatting;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -98,7 +96,7 @@ public class PolarizerBlockEntity extends ElectricBlockEntity implements IHaveGo
                     timer++;
                 } else {
                     timer = -1;
-                    inventory.setStackInSlot(0, recipe.get().getResultItem(Minecraft.getInstance().level.registryAccess()));
+                    inventory.setStackInSlot(0, recipe.get().getResultItem(level.registryAccess()));
                     TFMGUtils.spawnElectricParticles(level,getBlockPos());
                     sendStuff();
                 }


### PR DESCRIPTION
## Issue: 
The `PolarizerBlockEntity` causes the server to crash when a recipe is completed. This creates a chunk-ban where if the chunk containing the `PolarizerBlockEntity` is loaded, it will crash the server next tick.

## Exception: 
```
java.lang.RuntimeException: Attempted to load class net/minecraft/client/Minecraft for invalid dist DEDICATED_SERVER
...
at com.drmangotea.tfmg.blocks.electricity.polarizer.PolarizerBlockEntity.tick(PolarizerBlockEntity.java:101) ~[tfmg-0.9.3-1.20.1.jar%23589!/:0.9.3-1.20.1] {re:classloading}
at com.simibubi.create.foundation.blockEntity.SmartBlockEntityTicker.m_155252_(SmartBlockEntityTicker.java:15) ~[create-1.20.1-0.5.1.j.jar%23422!/:0.5.1.j] {re:classloading}
...
```

## Cause:
`PolarizerBlockEntity` attempts to get `level.registryAccess()` from the client but it's running on the server.

## Fix:
Use `level` inherited from `BlockEntity` instead of the client.

Fixes Issues #125 #114