### PR TITLE
Allows LGF engine to accept fuels matching the LOWGRADEFUEL tag

### DIFF
--- a/src/main/java/com/drmangotea/tfmg/blocks/engines/low_grade_fuel/LowGradeFuelEngineBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/blocks/engines/low_grade_fuel/LowGradeFuelEngineBlockEntity.java
@@ -2,6 +2,7 @@ package com.drmangotea.tfmg.blocks.engines.low_grade_fuel;
 
 import com.drmangotea.tfmg.registry.TFMGFluids;
 import com.drmangotea.tfmg.registry.TFMGSoundEvents;
+import com.drmangotea.tfmg.registry.TFMGTags;
 import com.simibubi.create.Create;
 import com.simibubi.create.content.equipment.goggles.IHaveGoggleInformation;
 import com.simibubi.create.content.equipment.wrench.IWrenchable;
@@ -31,6 +32,7 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ForgeCapabilities;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.templates.FluidTank;
@@ -455,13 +457,18 @@ public void write(CompoundTag compound, boolean clientPacket) {
 
         ItemStack stack = pPlayer.getItemInHand(pHand);
 
-        if(stack.is(TFMGFluids.CREOSOTE.getBucket().get())&&tankInventory.isEmpty()){
+        if (FluidUtil.getFluidContained(stack).isPresent())
+        {
+            if(TFMGTags.TFMGFluidTags.LOWGRADEFUEL.matches(FluidUtil.getFluidContained(stack).get().getFluid())&&tankInventory.isEmpty()){
 
-            tankInventory.setFluid(new FluidStack(TFMGFluids.CREOSOTE.get(),1000));
-            pPlayer.setItemInHand(pHand, Items.BUCKET.getDefaultInstance());
+                tankInventory.setFluid(new FluidStack(TFMGFluids.CREOSOTE.get(),1000));
+                pPlayer.setItemInHand(pHand, Items.BUCKET.getDefaultInstance());
 
-            return true;
+                return true;
+            }
         }
+
+
 
         return false;
 
@@ -482,7 +489,7 @@ public void write(CompoundTag compound, boolean clientPacket) {
         return new SmartFluidTank(1000, this::onFluidStackChanged){
             @Override
             public boolean isFluidValid(FluidStack stack) {
-                return stack.getFluid().isSame(validFuel());
+                return TFMGTags.TFMGFluidTags.LOWGRADEFUEL.matches(stack.getFluid());
             }
         };
     }

--- a/src/main/java/com/drmangotea/tfmg/registry/TFMGFluids.java
+++ b/src/main/java/com/drmangotea/tfmg/registry/TFMGFluids.java
@@ -72,7 +72,7 @@ public class TFMGFluids {
             KEROSENE = fuel("kerosene",TFMGTags.TFMGFluidTags.KEROSENE.tag,TFMGTags.TFMGFluidTags.FLAMMABLE.tag),
             GASOLINE = fuel("gasoline",TFMGTags.TFMGFluidTags.GASOLINE.tag,TFMGTags.TFMGFluidTags.FLAMMABLE.tag),
             DIESEL = fuel("diesel",TFMGTags.TFMGFluidTags.DIESEL.tag,TFMGTags.TFMGFluidTags.FLAMMABLE.tag),
-            CREOSOTE = fuel("creosote",TFMGTags.TFMGFluidTags.FLAMMABLE.tag)
+            CREOSOTE = fuel("creosote",TFMGTags.TFMGFluidTags.LOWGRADEFUEL.tag,TFMGTags.TFMGFluidTags.FLAMMABLE.tag)
 
             ;
 

--- a/src/main/java/com/drmangotea/tfmg/registry/TFMGTags.java
+++ b/src/main/java/com/drmangotea/tfmg/registry/TFMGTags.java
@@ -73,6 +73,7 @@ public class TFMGTags {
         GAS(NameSpace.MOD),
 
         FLAMMABLE(NameSpace.MOD),
+        LOWGRADEFUEL(NameSpace.FORGE),
         GASOLINE(NameSpace.FORGE),
         DIESEL(NameSpace.FORGE),
         KEROSENE(NameSpace.FORGE),


### PR DESCRIPTION
The low-grade fuel engine uses a hard fluid reference; substituting it for a tag reference would allow for greater compatibility with other mod packs.