### PR TITLE
Fix engines attempting to connect when not in a straight line.

### DIFF
--- a/src/main/java/com/drmangotea/tfmg/content/engines/types/AbstractSmallEngineBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/engines/types/AbstractSmallEngineBlockEntity.java
@@ -605,7 +605,10 @@ public abstract class AbstractSmallEngineBlockEntity extends AbstractEngineBlock
         Direction facing = getBlockState().getValue(HORIZONTAL_FACING);
         Direction updateDirection = facing.getOpposite();
 
-        if (level.getBlockEntity(getBlockPos().relative(facing)) instanceof AbstractSmallEngineBlockEntity be && be.getBlockState().getBlock() == this.getBlockState().getBlock()) {
+        if (level.getBlockEntity(getBlockPos().relative(facing)) instanceof AbstractSmallEngineBlockEntity be
+                && be.getBlockState().getBlock() == this.getBlockState().getBlock()
+                && be.getBlockState().getValue(HORIZONTAL_FACING) == getBlockState().getValue(HORIZONTAL_FACING)
+        ) {
             be.connect();
             return;
         }


### PR DESCRIPTION
This PR fixes #221. 
<img width="781" height="378" alt="Screenshot_20250816_125016" src="https://github.com/user-attachments/assets/655decf1-4c93-4228-bc73-88412239ed78" />
The problem in this issue is a bug where engine blocks attempt to connect to each-other without taking orientation into account. The effective result is a situation where placing two engine blocks facing in opposite ways causes the game to crash.