### PR TITLE
Fix bug where screwdriver invalidly casts all blockentities to TFMGPipeBlockEntity

### DIFF
--- a/src/main/java/com/drmangotea/tfmg/content/items/ScrewdriverItem.java
+++ b/src/main/java/com/drmangotea/tfmg/content/items/ScrewdriverItem.java
@@ -1,7 +1,6 @@
 package com.drmangotea.tfmg.content.items;
 
 import com.drmangotea.tfmg.content.decoration.pipes.TFMGPipeBlockEntity;
-import com.drmangotea.tfmg.content.engines.base.AbstractEngineBlockEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.LivingEntity;
@@ -24,17 +23,13 @@ public class ScrewdriverItem extends Item {
 
         Level level = pContext.getLevel();
 
-        if(level.getBlockEntity(positionClicked) instanceof AbstractEngineBlockEntity){
-
-
-
-            return super.useOn(pContext);
-        }
-        if(level.getBlockEntity(positionClicked)!=null) {
-            ((TFMGPipeBlockEntity) level.getBlockEntity(positionClicked)).toggleLock(player);
+        if (level.getBlockEntity(positionClicked) != null && level.getBlockEntity(positionClicked) instanceof TFMGPipeBlockEntity pipeBlockEntity) {
+            pipeBlockEntity.toggleLock(player);
             pContext.getItemInHand().hurtAndBreak(1, pContext.getPlayer(),
                     LivingEntity.getSlotForHand(pContext.getHand()));
+            return InteractionResult.SUCCESS;
+        } else {
+            return super.useOn(pContext);
         }
-        return InteractionResult.SUCCESS;
     }
 }


### PR DESCRIPTION
This PR fixes the bug report made by Aza'zel on discord (https://discord.com/channels/1033426837629571212/1406440226108473414).
The issue was that the screwdriver attempted to cast any and all block entities to TFMGPipeBlockEntity, which causes the game to crash if this is not possible. I have replaced the logic to always check whether the cast is possible.
Note that this does not magically fix the screwdriver working on create pipes. The screwdriver only works on the pipes introduced **by tfmg**. This is because normal create pipes do not extend TFMGPipeBlockEntity and therefore will not contain the logic for locking pipes.