### PR TITLE
Fix issue #237 in BlastStoveBlockEntity

### DIFF
--- a/src/main/java/com/drmangotea/tfmg/content/machinery/metallurgy/blast_stove/BlastStoveBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/machinery/metallurgy/blast_stove/BlastStoveBlockEntity.java
@@ -350,6 +350,10 @@ public class BlastStoveBlockEntity extends FluidTankBlockEntity implements IHave
     @SuppressWarnings("removal")
     public boolean addToGoggleTooltip(List<Component> tooltip, boolean isPlayerSneaking) {
 
+        if (getControllerBE() == null) {
+            return false;
+        }
+
         LangBuilder mb = CreateLang.translate("generic.unit.millibuckets");
 
         TFMGTexts.header("blast_stove").forGoggles(tooltip);


### PR DESCRIPTION
added check if genControllerBE() in BlastStoveBlockEntity is null when adding blast stove info to create goggles tooltip. If it is null return false. Fixes GitHub issue #237