### PR TITLE
fix create not being listed as a dependency for the mod, leading to unexpected behaviour

### DIFF
--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -77,3 +77,9 @@ side = "BOTH"
 # stop your mod loading on the server for example.
 #[features."${mod_id}"]
 #openGLVersion="[3.2,)"
+
+[[dependencies."${mod_id}"]]
+modId = "create"
+type = "required"
+versionRange = "[6.0.6,)"
+side = "BOTH"


### PR DESCRIPTION
This commit fixes issue #264 in which the player their client crashes in the event of an outdated version of the create mod. This is part of a broader problem - namely `create` not being listed as a dependency in `neoforge.mods.toml`. I've added it and made sure the mod now only starts on versions it supports. (Please note, in new releases, if new create features will be used, this value has to be updated.)