### PR TITLE
Fix NPE in RegularEngineBlockEntity.isCylinderSame when FUELS component is null

### DIFF
--- a/src/main/java/com/drmangotea/tfmg/content/engines/types/regular_engine/RegularEngineBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/engines/types/regular_engine/RegularEngineBlockEntity.java
@@ -33,6 +33,7 @@ import net.neoforged.api.distmarker.OnlyIn;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static com.drmangotea.tfmg.content.engines.base.EngineProperties.*;
 import static com.drmangotea.tfmg.content.engines.types.regular_engine.RegularEngineBlock.EXTENDED;
@@ -261,7 +262,7 @@ public class RegularEngineBlockEntity extends AbstractSmallEngineBlockEntity {
                             continue;
 
                         CompoundTag tagInside = be.pistonInventory.getItem(y).get(TFMGDataComponents.FUELS);
-                        if (!tagInside.toString().equals(tag.toString()))
+                        if (!Objects.equals(tagInside, tag))
                             return false;
 
                     }


### PR DESCRIPTION
## Problem
Client crash when interacting with a TFMG regular engine while `isCylinderSame` runs:

```
java.lang.NullPointerException: Cannot invoke "net.minecraft.nbt.CompoundTag.toString()" because "tagInside" is null
at RegularEngineBlockEntity.isCylinderSame(RegularEngineBlockEntity.java:264)
```

Piston slots can hold engine cylinders whose `TFMGDataComponents.FUELS` is missing (e.g. older worlds, creative/JEI stacks, edge cases).

## Change
- Import `java.util.Objects`.
- Replace `tagInside.toString().equals(tag.toString())` with `Objects.equals(tagInside, tag)`.

This removes the NPE and compares tags with `CompoundTag.equals` semantics instead of string equality.

## Testing
Reproduce: multiblock with at least one piston cylinder lacking `FUELS`, then use a valid cylinder on the engine — before: crash; after: no crash (mismatch returns `false` when one side is null).