### PR TITLE
More accurate way to calculate fuel consumption (using float)

### DIFF
--- a/src/main/java/com/drmangotea/tfmg/content/engines/types/AbstractSmallEngineBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/engines/types/AbstractSmallEngineBlockEntity.java
@@ -71,8 +71,7 @@ public abstract class AbstractSmallEngineBlockEntity extends AbstractEngineBlock
         componentsInventory = new EngineComponentsInventory(this, EngineProperties.commonRegularComponents());
     }
 
-    public int getFuelConsumption() {
-
+    public float getFuelConsumptionFloat() {
         if (rpm == 0)
             return 0;
 
@@ -80,8 +79,22 @@ public abstract class AbstractSmallEngineBlockEntity extends AbstractEngineBlock
 
         float coolingFluidModifier = coolingFluid > 0 ? 0.7f : 1f;
 
+        return ((12.5f * (1 / efficiencyModifier()) * getSpeedEfficiency() * highestSignal / 15 * oilModifier * coolingFluidModifier) * (engineLength() )+ 1);
+    }
 
-        return (int) ((12.5f * (1 / efficiencyModifier()) * getSpeedEfficiency() * highestSignal / 15 * oilModifier * coolingFluidModifier) * (engineLength() )+ 1);
+    public int getFuelConsumption() {
+        if (!((Object)this instanceof BlockEntity be)) return 0;
+        if (be.getLevel() == null) return 0;
+
+        // use float for more accuracy
+        float consumption = getFuelConsumptionFloat();
+
+        // we cannot use float as fuel consumption, so we compensate it with this block
+        // basically we sum up tail until it hits 1, but in more optimized way
+        long gameTime = be.getLevel().getGameTime();
+        float tail = consumption - (int)consumption;
+        if (tail > 0.0f && gameTime % (1.f/tail) < 1.f) return (int)consumption+1;
+        else return (int)consumption;
     }
 
     public void detashEngines() {

--- a/src/main/java/com/drmangotea/tfmg/content/engines/types/regular_engine/RegularEngineBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/engines/types/regular_engine/RegularEngineBlockEntity.java
@@ -394,7 +394,8 @@ public class RegularEngineBlockEntity extends AbstractSmallEngineBlockEntity {
         TFMGTexts.Engine.rpm(rpm).forGoggles(tooltip, 1);
         TFMGTexts.Engine.signal((int) (highestSignal*15)).forGoggles(tooltip, 1);
         TFMGTexts.Engine.torque(torque).forGoggles(tooltip, 1);
-        TFMGTexts.Engine.fuelConsumption(getFuelConsumption()).forGoggles(tooltip, 1);
+        // fuel consumption supports float, so changed getFuelConsumption() to getFuelConsumptionFloat() for more accuracy
+        TFMGTexts.Engine.fuelConsumption(getFuelConsumptionFloat()).forGoggles(tooltip, 1);
         if(oil>0){
             TFMGTexts.Engine.oil(oil).forGoggles(tooltip);
         }


### PR DESCRIPTION
Fuel consumption previously was calculated as integer, causing inaccurate fuel consumption, oftenly even no consumption at all. Safely changed it to float for more accuracy.