### PR TITLE
Fix some bugs and crashes

### DIFF
--- a/src/main/java/com/drmangotea/tfmg/base/lang/TFMGTexts.java
+++ b/src/main/java/com/drmangotea/tfmg/base/lang/TFMGTexts.java
@@ -13,7 +13,7 @@ import net.minecraft.world.item.ItemStack;
  */
 public class TFMGTexts {
     public static String percent(double value) {
-        return TFMGLang.number(value) + "%";
+        return String.valueOf(value) + "%";
     }
     // Electricity info
     public static String power(double value) {

--- a/src/main/java/com/drmangotea/tfmg/content/decoration/tanks/steel/SteelTankBlock.java
+++ b/src/main/java/com/drmangotea/tfmg/content/decoration/tanks/steel/SteelTankBlock.java
@@ -339,6 +339,9 @@ public class SteelTankBlock extends Block implements IWrenchable, IBE<SteelTankB
         if (tankBE == null)
             return false;
 
+        if (tankBE.getControllerBE() == null)
+            return false;
+
         if (assemble && tankBE.getControllerBE().isDistillationTower)
             return false;
 

--- a/src/main/java/com/drmangotea/tfmg/content/decoration/tanks/steel/SteelTankBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/decoration/tanks/steel/SteelTankBlockEntity.java
@@ -459,6 +459,7 @@ public class SteelTankBlockEntity extends FluidTankBlockEntity implements IHaveG
             tankInventory.readFromNBT(registries, compound.getCompound("TankContent"));
             if (tankInventory.getSpace() < 0)
                 tankInventory.drain(-tankInventory.getSpace(), IFluidHandler.FluidAction.EXECUTE);
+            isDistillationTower = compound.getBoolean("IsDistillationTower");          
         }
 
         boiler.read(compound.getCompound("Boiler"), width * width * height);
@@ -486,7 +487,6 @@ public class SteelTankBlockEntity extends FluidTankBlockEntity implements IHaveG
                 fluidLevel = LerpedFloat.linear()
                         .startWithValue(fillState);
             fluidLevel.chase(fillState, 0.5f, LerpedFloat.Chaser.EXP);
-            isDistillationTower = compound.getBoolean("IsDistillationTower");
         }
         if (luminosity != prevLum && hasLevel())
             level.getChunkSource()

--- a/src/main/java/com/drmangotea/tfmg/content/decoration/tanks/steel/SteelTankBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/decoration/tanks/steel/SteelTankBlockEntity.java
@@ -295,6 +295,10 @@ public class SteelTankBlockEntity extends FluidTankBlockEntity implements IHaveG
     public void updateBoilerState() {
         if (!isController())
             return;
+
+        if (getControllerBE() == null)
+            return;
+
         boolean wasTower = isDistillationTower;
         boolean changed = evaluate();
 

--- a/src/main/java/com/drmangotea/tfmg/content/decoration/tanks/steel/SteelTankBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/decoration/tanks/steel/SteelTankBlockEntity.java
@@ -416,15 +416,18 @@ public class SteelTankBlockEntity extends FluidTankBlockEntity implements IHaveG
     }
     @Override
     public boolean addToGoggleTooltip(List<Component> tooltip, boolean isPlayerSneaking) {
-        SteelTankBlockEntity controllerTE = getControllerBE();
+        SteelTankBlockEntity controllerBE = getControllerBE();
         if (isDistillationTower)
             return false;
-        if (getControllerBE() != null)
-            if (getControllerBE().isDistillationTower)
-                return false;
+
+        if (controllerBE == null)
+            return false;
+
+        if (controllerBE.isDistillationTower)
+            return false;
 
         return containedFluidTooltip(tooltip, isPlayerSneaking,
-                level.getCapability(Capabilities.FluidHandler.BLOCK, getControllerBE().getBlockPos(), null));
+                level.getCapability(Capabilities.FluidHandler.BLOCK, controllerBE.getBlockPos(), null));
     }
 
     @Override

--- a/src/main/java/com/drmangotea/tfmg/content/engines/types/AbstractSmallEngineBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/engines/types/AbstractSmallEngineBlockEntity.java
@@ -404,9 +404,12 @@ public abstract class AbstractSmallEngineBlockEntity extends AbstractEngineBlock
         if (itemStack.is(TFMGItems.COOLING_FLUID_BOTTLE.get())) {
 
             if (level.getBlockEntity(controller) instanceof AbstractSmallEngineBlockEntity be) {
+                Integer amount = itemStack.get(TFMGDataComponents.AMOUNT);
+                if (amount == null)
+                    return true;
 
-                int toDrain = Math.min(2000 - coolingFluid, itemStack.get(TFMGDataComponents.AMOUNT));
-                itemStack.set(TFMGDataComponents.AMOUNT, itemStack.get(TFMGDataComponents.AMOUNT) - toDrain);
+                int toDrain = Math.min(2000 - coolingFluid, amount);
+                itemStack.set(TFMGDataComponents.AMOUNT, amount - toDrain);
                 be.coolingFluid += toDrain;
                 level.playSound(null, getBlockPos(), SoundEvents.BUCKET_FILL, SoundSource.BLOCKS, 1f, 1f);
                 return true;
@@ -414,8 +417,12 @@ public abstract class AbstractSmallEngineBlockEntity extends AbstractEngineBlock
         }
         if (itemStack.is(TFMGItems.OIL_CAN.get())) {
             if (level.getBlockEntity(controller) instanceof AbstractSmallEngineBlockEntity be) {
-                int toDrain = Math.min(2000 - oil, itemStack.get(TFMGDataComponents.AMOUNT));
-                itemStack.set(TFMGDataComponents.AMOUNT, itemStack.get(TFMGDataComponents.AMOUNT) - toDrain);
+                Integer amount = itemStack.get(TFMGDataComponents.AMOUNT);
+                if (amount == null)
+                    return true;
+
+                int toDrain = Math.min(2000 - oil, amount);
+                itemStack.set(TFMGDataComponents.AMOUNT, amount - toDrain);
                 be.oil += toDrain;
                 level.playSound(null, getBlockPos(), SoundEvents.BUCKET_FILL, SoundSource.BLOCKS, 1f, 1f);
                 updateRotation();

--- a/src/main/java/com/drmangotea/tfmg/content/engines/types/AbstractSmallEngineBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/engines/types/AbstractSmallEngineBlockEntity.java
@@ -406,9 +406,9 @@ public abstract class AbstractSmallEngineBlockEntity extends AbstractEngineBlock
             if (level.getBlockEntity(controller) instanceof AbstractSmallEngineBlockEntity be) {
                 Integer amount = itemStack.get(TFMGDataComponents.AMOUNT);
                 if (amount == null)
-                    return true;
+                    return false;
 
-                int toDrain = Math.min(2000 - coolingFluid, amount);
+                int toDrain = Math.min(2000 - be.coolingFluid, amount);
                 itemStack.set(TFMGDataComponents.AMOUNT, amount - toDrain);
                 be.coolingFluid += toDrain;
                 level.playSound(null, getBlockPos(), SoundEvents.BUCKET_FILL, SoundSource.BLOCKS, 1f, 1f);

--- a/src/main/java/com/drmangotea/tfmg/content/engines/types/AbstractSmallEngineBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/engines/types/AbstractSmallEngineBlockEntity.java
@@ -430,8 +430,10 @@ public abstract class AbstractSmallEngineBlockEntity extends AbstractEngineBlock
             }
         }
         if (itemStack.is(TFMGFluids.COOLING_FLUID.getBucket().get())) {
-            if (coolingFluid <= 1000) {
-                coolingFluid += 1000;
+            if (level.getBlockEntity(controller) instanceof AbstractSmallEngineBlockEntity be) {
+                if (be.coolingFluid > 1000)
+                    return false;
+                be.coolingFluid += 1000;
                 player.setItemInHand(hand, Items.BUCKET.getDefaultInstance());
                 level.playSound(null, getBlockPos(), SoundEvents.BUCKET_FILL, SoundSource.BLOCKS, 1f, 1f);
                 updateRotation();

--- a/src/main/java/com/drmangotea/tfmg/content/engines/types/AbstractSmallEngineBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/engines/types/AbstractSmallEngineBlockEntity.java
@@ -419,9 +419,9 @@ public abstract class AbstractSmallEngineBlockEntity extends AbstractEngineBlock
             if (level.getBlockEntity(controller) instanceof AbstractSmallEngineBlockEntity be) {
                 Integer amount = itemStack.get(TFMGDataComponents.AMOUNT);
                 if (amount == null)
-                    return true;
+                    return false;
 
-                int toDrain = Math.min(2000 - oil, amount);
+                int toDrain = Math.min(2000 - be.oil, amount);
                 itemStack.set(TFMGDataComponents.AMOUNT, amount - toDrain);
                 be.oil += toDrain;
                 level.playSound(null, getBlockPos(), SoundEvents.BUCKET_FILL, SoundSource.BLOCKS, 1f, 1f);

--- a/src/main/java/com/drmangotea/tfmg/content/engines/types/AbstractSmallEngineBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/engines/types/AbstractSmallEngineBlockEntity.java
@@ -441,8 +441,10 @@ public abstract class AbstractSmallEngineBlockEntity extends AbstractEngineBlock
             }
         }
         if (itemStack.is(TFMGFluids.LUBRICATION_OIL.getBucket().get())) {
-            if (oil <= 1000) {
-                oil += 1000;
+            if (level.getBlockEntity(controller) instanceof AbstractSmallEngineBlockEntity be) {
+                if (be.oil > 1000) 
+                    return false;
+                be.oil += 1000;
                 player.setItemInHand(hand, Items.BUCKET.getDefaultInstance());
                 level.playSound(null, getBlockPos(), SoundEvents.BUCKET_FILL, SoundSource.BLOCKS, 1f, 1f);
                 updateRotation();

--- a/src/main/java/com/drmangotea/tfmg/content/machinery/metallurgy/blast_stove/BlastStoveBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/machinery/metallurgy/blast_stove/BlastStoveBlockEntity.java
@@ -437,16 +437,19 @@ public class BlastStoveBlockEntity extends FluidTankBlockEntity implements IHave
                 Capabilities.FluidHandler.BLOCK,
                 TFMGBlockEntities.BLAST_STOVE.get(),
                 (be, context) -> {
-                    if (be.fluidCapability == null)
-                        be.refreshCapability();
-                    if (be.secondaryCapability == null)
-                        be.refreshCapability();
+                    if (be.getControllerBE() == null)
+                        return null;
+                    
+                    if (be.getControllerBE().fluidCapability == null)
+                        be.getControllerBE().refreshCapability();
+                    if (be.getControllerBE().secondaryCapability == null)
+                        be.getControllerBE().refreshCapability();
 
 
                     if (context.getAxis() == Direction.Axis.Y) {
-                        return be.primaryCapability;
+                        return be.getControllerBE().primaryCapability;
                     } else if (be.getController().getY() == be.getBlockPos().getY()) {
-                        return be.secondaryCapability;
+                        return be.getControllerBE().secondaryCapability;
                     }
 
                     return null;

--- a/src/main/java/com/drmangotea/tfmg/content/machinery/misc/firebox/FireboxBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/machinery/misc/firebox/FireboxBlockEntity.java
@@ -92,10 +92,12 @@ public class FireboxBlockEntity extends SmartBlockEntity implements IHaveGoggleI
     public void lazyTick() {
         super.lazyTick();
 
-        boolean wasRunning = running;
-
-
         FireboxBlockEntity controller = isController() ? this : getControllerBE();
+
+        if (controller == null)
+            return;
+
+        boolean wasRunning = running;
 
         if (!canBurn(controller)) {
             if (wasRunning)


### PR DESCRIPTION
My solution to a few annoying bugs.

Changes:

crash fixes:
- fix crash when move steel tank (#405)
- fix crash when break steel tank with goggles (#390)
- fix crash on load/unload chunk with firebox
- fix crash when using unfilled cooling fluid bottle or oil can before first fill

game play bugs fixes:
- fix overflow of cooling fluid during engine fill using the cooling fluid bottle
- fix overflow of oil during engine fill using the oil can
- fix incorrect engine filling when using an oil bucket
- fix incorrect engine filling when using an cooling fluid bucket
- fix multi-block blast stove fluid i/o after chunk reload (#372)
- fix distillation tower heat level after chunk/world reload (#384)

other fixes:
- fix polarizer tooltip