### PR TITLE
blast stove sizing fix

### DIFF
--- a/src/main/java/com/drmangotea/tfmg/content/machinery/metallurgy/blast_stove/BlastStoveBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/machinery/metallurgy/blast_stove/BlastStoveBlockEntity.java
@@ -505,5 +505,7 @@ public class BlastStoveBlockEntity extends FluidTankBlockEntity implements IHave
             return getMaxHeight();
         return getMaxWidth();
     }
+	
+	@Override
+	public int getMaxWidth() { return MAX_SIZE; }
 }
-


### PR DESCRIPTION
Fixes Blast Stoves attempting a 3x3 configuration and causing rendering errors by correctly defining the maximum size as 2x2.