### PR TITLE
fix(distillation): resolve heat from the correct tank controller

### DIFF
--- a/src/main/java/com/drmangotea/tfmg/content/decoration/tanks/steel/SteelTankBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/decoration/tanks/steel/SteelTankBlockEntity.java
@@ -133,6 +133,8 @@ public class SteelTankBlockEntity extends FluidTankBlockEntity implements IHaveG
     @Override
     public void initialize() {
         super.initialize();
+        if (isDistillationTower)
+            updateTemperature();
         sendData();
         if (level.isClientSide)
             invalidateRenderBoundingBox();

--- a/src/main/java/com/drmangotea/tfmg/content/machinery/oil_processing/distillation_tower/controller/DistillationControllerBlockEntity.java
+++ b/src/main/java/com/drmangotea/tfmg/content/machinery/oil_processing/distillation_tower/controller/DistillationControllerBlockEntity.java
@@ -100,8 +100,9 @@ public class DistillationControllerBlockEntity extends SmartBlockEntity implemen
         if (!(beBehind instanceof SteelTankBlockEntity be))
             return;
 
+        SteelTankBlockEntity controllerBe = be.getControllerBE() == null ? be : be.getControllerBE();
 
-        if (outputs.isEmpty() || be.activeHeat == 0)
+        if (outputs.isEmpty() || controllerBe.activeHeat == 0)
             return;
 
         findRecipe(outputs);
@@ -110,7 +111,7 @@ public class DistillationControllerBlockEntity extends SmartBlockEntity implemen
             return;
 
         ///
-        float speedModifier = (float) be.activeHeat / 2;
+        float speedModifier = (float) controllerBe.activeHeat / 2;
         if (recipe.getInputFluid().amount() * speedModifier > tank.getFluidAmount())
             return;
 
@@ -168,8 +169,9 @@ public class DistillationControllerBlockEntity extends SmartBlockEntity implemen
 
         BlockEntity beBehind = level.getBlockEntity(getBlockPos().relative(getFacing(getBlockState()).getOpposite()));
         if (beBehind instanceof SteelTankBlockEntity be) {
+            SteelTankBlockEntity controllerBe = be.getControllerBE() == null ? be : be.getControllerBE();
             TFMGTexts.header("distillation_tower").style(ChatFormatting.GRAY).forGoggles(tooltip, 1);
-            TFMGTexts.Distillation.level(be.getControllerBE().activeHeat).forGoggles(tooltip, 1);
+            TFMGTexts.Distillation.level(controllerBe.activeHeat).forGoggles(tooltip, 1);
             TFMGTexts.Distillation.outputs(getOutputs().toArray().length).forGoggles(tooltip, 1);
         } else
             TFMGTexts.Distillation.tankNotFound().forGoggles(tooltip, 1);


### PR DESCRIPTION
The tower read Steel Tank heat from whichever tank segment happened to be adjacent to the controller, which is not necessarily the segment that keeps activeHeat up to date. This left manageRecipe() reading a stale 0 after a chunk unload/reload, even though the goggles tooltip (which already resolved the real controller) showed the correct heat.

- DistillationControllerBlockEntity: resolve the tank's real controller via getControllerBE() before reading activeHeat, in both manageRecipe() and addToGoggleTooltip() (the latter also had a latent NullPointerException from calling .activeHeat directly on a possibly-null getControllerBE() result).
- SteelTankBlockEntity: recalculate heat in initialize() so it is correct as soon as the block entity loads, instead of waiting for the next lazyTick.

Fixes #384